### PR TITLE
Fix Windows CI test failures

### DIFF
--- a/src/Fedit/Plugins.fs
+++ b/src/Fedit/Plugins.fs
@@ -620,11 +620,13 @@ module Plugins =
                             // Relative library/queries paths are the plugin folder's.
                             collector.Languages
                             |> List.map (fun grammar ->
+                                // Fedit.PluginHost links this file standalone (no Fedit.Primitives),
+                                // so normalize inline rather than via Paths.norm.
                                 let resolve (p: string) =
                                     if Path.IsPathRooted p then
-                                        p
+                                        p.Replace('\\', '/')
                                     else
-                                        Path.Combine(loaded.Path, p)
+                                        Path.Combine(loaded.Path, p).Replace('\\', '/')
 
                                 { grammar with
                                     Library = resolve grammar.Library

--- a/tests/Fedit.Tests/IgnoreTests.fs
+++ b/tests/Fedit.Tests/IgnoreTests.fs
@@ -20,13 +20,23 @@ let private matches (text: string) (path: string) (isDirectory: bool) =
 
 /// A throwaway directory populated from `entries`: `a/b.txt` is a file,
 /// `a/b/` a directory. `.gitignore` contents go in as ordinary files.
+/// Entries with characters illegal in a filename on this filesystem (e.g.
+/// `*` on Windows) are skipped rather than materialized — the differential
+/// check against git compares only what's actually on disk, so a skip keeps
+/// both sides in sync instead of desyncing expected vs. actual.
 let private tempTree (entries: (string * string) list) =
     let root =
         Path.Combine(Path.GetTempPath(), "fedit-ignore-" + Path.GetRandomFileName())
 
     Directory.CreateDirectory root |> ignore
 
-    for relative, contents in entries do
+    let invalidChars = Path.GetInvalidFileNameChars()
+
+    let representable (relative: string) =
+        relative.TrimEnd('/').Split('/')
+        |> Array.forall (fun s -> s.IndexOfAny(invalidChars) < 0)
+
+    for relative, contents in entries |> List.filter (fst >> representable) do
         let full = Path.Combine(root, relative)
 
         if relative.EndsWith "/" then

--- a/tests/Fedit.Tests/PluginHostTests.fs
+++ b/tests/Fedit.Tests/PluginHostTests.fs
@@ -281,7 +281,7 @@ let ``a plugin's language server and grammar reach the editor and the grammar hi
 
         let grammar = registry.Languages |> List.find (fun g -> g.Name = "showcase")
         Assert.True(Path.IsPathRooted grammar.Library, "library path resolved against the plugin folder")
-        Assert.Equal(Path.Combine(grammars, "libtree-sitter-showcase.dylib"), grammar.Library)
+        Assert.Equal(Paths.norm (Path.Combine(grammars, "libtree-sitter-showcase.dylib")), grammar.Library)
 
         if File.Exists native then
             // The editor side: the spec lands in the highlight registry.


### PR DESCRIPTION
## Summary
- `IgnoreTests.tempTree` materialized a fixture path literally named `foo*` — legal on Unix, illegal on NTFS (`*` is a reserved char), so `File.WriteAllText` threw `IOException` on Windows. Now filters out any fixture entry containing filesystem-illegal characters before creating it; the differential check against git only compares what's actually on disk, so skipping creation keeps expected/actual in sync automatically.
- `Plugins.fs` resolved plugin grammar `Library`/`Queries` paths via `Path.Combine`, which emits `\` on Windows — violating the project's canonical forward-slash path convention (see CLAUDE.md) and causing `PluginHostTests`' string-equality assertion to fail on Windows. Normalized inline (`Plugins.fs` links standalone into `Fedit.PluginHost` without `Fedit.Primitives`, so `Paths.norm` isn't reachable there).

Both were caught chasing down Windows CI failures on the two dependabot PRs (#32, #33) that were otherwise green on Linux/macOS. Confirmed the failures reproduce on `main` itself, not just the PR branches.

## Test plan
- [x] `just check` (format, build, test, verify-generated) passes locally on macOS — 1313 tests pass
- [ ] CI green on all three platforms (Windows was the one failing before this fix)